### PR TITLE
Missing explicit return at the end of function able to return non-Non…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ fail_under = 100
 extend-ignore = E203
 max-complexity = 13
 max-line-length = 88
+require-plugins =
+    flake8-return
 
 [isort]
 known_first_party = akismet


### PR DESCRIPTION
…e value

Linting tools get confused because an Exception is being raised in a non-standard way.

Mypy will also complain about these three instances...
```
./akismet/src/akismet.py:189:9: R503 missing explicit return at the end of function able to return non-None value.
        self._protocol_error(operation, response)
        ^
./akismet/src/akismet.py:240:13: R503 missing explicit return at the end of function able to return non-None value.
            cls._protocol_error("verify_key", response)
            ^
./akismet/src/akismet.py:265:13: R503 missing explicit return at the end of function able to return non-None value.
            self._protocol_error("comment_check", response)
            ^
3     R503 missing explicit return at the end of function able to return non-None value.
```